### PR TITLE
chore: add commitlint package support metadata

### DIFF
--- a/packages/commitlint/package.json
+++ b/packages/commitlint/package.json
@@ -7,6 +7,10 @@
     "url": "https://github.com/bn-digital/config",
     "directory": "packages/commitlint-config"
   },
+  "homepage": "https://github.com/bn-digital/configs#readme",
+  "bugs": {
+    "url": "https://github.com/bn-digital/configs/issues"
+  },
   "main": "index.js",
   "readme": "README.md",
   "keywords": [


### PR DESCRIPTION
## Summary
- add homepage and bugs metadata to `@bn-digital/commitlint-config`
- point users to the repository README and issue tracker from npm
- leave runtime code, dependencies, package version, and package contents unchanged

## Verification
- node package metadata assertion
- npm pack --dry-run --ignore-scripts --json from `packages/commitlint`
- git diff --check

The package has no test script; only `calver` and `release` scripts are defined.